### PR TITLE
Iniciar desenvolvimento da interface de etapas do FunnelCraft GOD MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# FunnelCraft GOD MODE
+
+This repository contains the early development of **FunnelCraft GOD MODE**, a premium WordPress plugin focused on visual sales funnels. The initial version sets up a basic admin page with a drag & drop prototype for connecting stages. Assets are loaded using Tailwind via CDN for quick prototyping.
+
+## Development Setup
+
+The plugin is located in `funnelcraft-god-mode/`.
+
+### Dependencies
+
+This project intends to use the following libraries:
+
+- `elementor`
+- `tailwindcss`
+- `stripe-php`
+- `mailchimp-marketing`
+- `wp-api-fetch`
+
+Due to environment limitations these packages have not been installed yet. They are declared in `package.json` and `composer.json` for future installation.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "viniarte/funnelcraft-god-mode",
+    "description": "FunnelCraft GOD MODE plugin",
+    "type": "project",
+    "require": {
+        "stripe/stripe-php": "^12.0",
+        "mailchimp/marketing": "^3.0"
+    }
+}

--- a/funnelcraft-god-mode/assets/css/builder.css
+++ b/funnelcraft-god-mode/assets/css/builder.css
@@ -1,0 +1,3 @@
+.stage{
+    cursor: move;
+}

--- a/funnelcraft-god-mode/assets/js/builder.js
+++ b/funnelcraft-god-mode/assets/js/builder.js
@@ -1,0 +1,44 @@
+(function($){
+    function Stage(id, label){
+        this.id = id;
+        this.label = label;
+    }
+
+    function Builder(){
+        this.stages = [];
+        this.connections = [];
+    }
+
+    Builder.prototype.addStage = function(label){
+        var id = 'stage-' + (this.stages.length + 1);
+        var stage = new Stage(id, label);
+        this.stages.push(stage);
+        $('#funnelcraft-builder').append('<div draggable="true" class="stage border rounded p-2 m-2 bg-white" id="'+id+'">'+label+'</div>');
+    };
+
+    Builder.prototype.connect = function(fromId, toId){
+        this.connections.push({from: fromId, to: toId});
+    };
+
+    $(function(){
+        var builder = new Builder();
+        builder.addStage('Start');
+        builder.addStage('Thank You');
+
+        $('#funnelcraft-builder').on('dragstart', '.stage', function(e){
+            e.originalEvent.dataTransfer.setData('text/plain', e.target.id);
+        });
+
+        $('#funnelcraft-builder').on('drop', '.stage', function(e){
+            e.preventDefault();
+            var fromId = e.originalEvent.dataTransfer.getData('text');
+            var toId = e.target.id;
+            if(fromId !== toId){
+                builder.connect(fromId, toId);
+                alert('Connected '+fromId+' -> '+toId);
+            }
+        }).on('dragover', '.stage', function(e){
+            e.preventDefault();
+        });
+    });
+})(jQuery);

--- a/funnelcraft-god-mode/funnelcraft-god-mode.php
+++ b/funnelcraft-god-mode/funnelcraft-god-mode.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name: FunnelCraft GOD MODE
+ * Description: Visual funnel builder with drag & drop powered by Elementor integration.
+ * Version: 0.1.0
+ * Author: viniarte
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class FunnelCraft_God_Mode {
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'elementor/init', [ $this, 'elementor_init' ] );
+    }
+
+    public function register_admin_page() {
+        add_menu_page( 'FunnelCraft', 'FunnelCraft', 'manage_options', 'funnelcraft', [ $this, 'builder_page' ] );
+    }
+
+    public function builder_page() {
+        echo '<div id="funnelcraft-builder" class="wrap"><h1>FunnelCraft Builder</h1></div>';
+    }
+
+    public function enqueue_assets( $hook ) {
+        if ( $hook !== 'toplevel_page_funnelcraft' ) {
+            return;
+        }
+        // Tailwind via CDN for prototype.
+        wp_enqueue_style( 'funnelcraft-tailwind', 'https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css' );
+        wp_enqueue_style( 'funnelcraft-builder', plugins_url( 'assets/css/builder.css', __FILE__ ), [], '0.1.0' );
+        wp_enqueue_script( 'funnelcraft-builder', plugins_url( 'assets/js/builder.js', __FILE__ ), [ 'jquery' ], '0.1.0', true );
+    }
+
+    public function elementor_init() {
+        // Placeholder for Elementor widgets registration.
+    }
+}
+
+new FunnelCraft_God_Mode();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "funnelcraft-god-mode",
+  "version": "0.1.0",
+  "description": "Visual funnel builder for WordPress",
+  "dependencies": {
+    "elementor": "latest",
+    "tailwindcss": "^2.2.19",
+    "stripe-php": "latest",
+    "mailchimp-marketing": "latest",
+    "wp-api-fetch": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- add FunnelCraft GOD MODE plugin skeleton
- include basic drag & drop builder prototype
- define composer/package dependencies
- document setup in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce9d98b308330bed5ec3cddc967a3